### PR TITLE
Add CI GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      # 必要なパッケージをインストールして、pnpm run buildを実行する
+      - uses: withastro/action@v2

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "astro": "astro",
     "format": "prettier --write ."
   },
+  "packageManager": "pnpm@9.15.0",
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/tailwind": "^5.1.3",


### PR DESCRIPTION
Resolve #2 

mainブランチにpushしたとき、またはpull requestを作成したり更新したりしたときに、`pnpm run build` (`astro check && astro build`)が実行されるようにします。