### PR TITLE
ビルド時のbase URLを./2025にする

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,6 @@ import tailwind from "@astrojs/tailwind";
 
 // https://astro.build/config
 export default defineConfig({
+  base: "/2025",
   integrations: [tailwind()]
 });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,13 @@
+---
+import { withBase } from "../utils/withBase";
+---
+
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={withBase("favicon.svg")} />
     <meta name="generator" content={Astro.generator} />
     <title>Astro Basics</title>
   </head>

--- a/src/utils/withBase.ts
+++ b/src/utils/withBase.ts
@@ -1,0 +1,6 @@
+/** Astroに設定した[base](https://docs.astro.build/en/reference/configuration-reference/#base)を先頭に付与したパスを返す */
+// Based on https://github.com/GoCon/2024/blob/ddf8dcc1779cbe9a7becc3e6b8538dce1c627323/src/utils/concatWithBase.ts
+export const withBase = (path?: string) => {
+  const base = import.meta.env.BASE_URL;
+  return path ? `${base}/${path}` : base;
+};


### PR DESCRIPTION
Resolve #8.

リンクやアセットのURLにもbase URLを付加する必要があるので、[GoCon/2024の実装](https://github.com/GoCon/2024/blob/ddf8dcc1779cbe9a7becc3e6b8538dce1c627323/src/utils/concatWithBase.ts)を参考にしてヘルパー関数を追加しています。

https://www.npmjs.com/package/astro-relative-links ([zenn](https://zenn.dev/ixkaito/articles/astro-relative-links)) というintegrationを使うとビルド時にbase URLをパスを自動変換してくれるようですが、Astro v5には未対応（<https://github.com/ixkaito/astro-relative-links/issues/20>）でした。