### PR TITLE
PRごとにプレビューページを作成するworkflowを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,9 @@
-name: CI
+name: Deploy
 
 on:
   push:
     branches:
       - main
-  pull_request:
-
 
 jobs:
   build:
@@ -17,7 +15,6 @@ jobs:
       - uses: withastro/action@v3
       
   deploy:
-    if: github.ref == 'refs/heads/main'
     needs: build
     permissions:
       pages: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,45 @@
+name: Preview
+
+on:
+  pull_request:
+
+jobs:
+  build_and_deploy_preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          path: main
+      - name: Checkout preview repo
+        uses: actions/checkout@v4
+        with:
+          repository: GoWorkshopConference/2025-preview
+          path: preview
+          ssh-key: ${{ secrets.PREVIEW_DEPLOY_KEY }}
+      - name: Build 
+        uses: withastro/action@v3
+        with:
+          path: main
+        env:
+          BASE_URL: /2025-preview/${{ github.event.number }}
+      - name: Deploy to preview repo
+        run: |
+          rm -r ./preview/$PR_NUMBER
+          cp -r ./main/dist ./preview/$PR_NUMBER
+          cd ./preview
+          
+          # Set bot user identity
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          if [ -z "$(git status --porcelain)" ]; then 
+            echo "::notice ::No changes detected, exiting"
+            exit 0
+          fi
+
+          git add .
+          git commit -m "Update preview"
+          git push
+        env:
+          PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Pull Requestごとのプレビューページを `https://goworkshopconference.github.io/2025-preview/${PR_NUMBER}/` にデプロイするGitHub Action workflowを追加します。

# 背景

- 実装途中のデザインなどを共有してフィードバックを受けるときにプレビューページがあると便利。
- Vercelの[Preview Deployments Features](https://vercel.com/docs/deployments/preview-deployments#preview-deployments-features)を使いたかったが、GitHub OrganizationではProプランを契約しなければ利用できない。

# 実装方針

GitHub ActionとGitHub Pagesで実装しました。大まかな構成は次のようになっています。

- このリポジトリのGitHub Actionでpull_requestイベントを検知して、ページをビルドして[GoWorkshopConference/2025-preview](https://github.com/GoWorkshopConference/2025-preview)の`${PR_NUMBER}`サブディレクトリに置く
- ビルドされたページは`GoWorkshopConference/2025-preview`のGitHub Pagesで公開される

# 手を抜いたところ

- GoWorkshopConference/2025-previewへのpushにはDeploy Keyを使っています。
    - キーが漏洩した際のリスクを低減するため、Deploy KeyよりもGitHub Appsを使うことが推奨されています。
    - 今回はプレビュー用のページなので簡単な方法を選びました。
- Pull Requestをcloseした際のプレビューの削除は未実装です。
- Pull Requestにプレビュー用のページのURLを通知する機能も未実装です。

# 参考情報

- どうやらGitHub Pages本体にも同様の機能（GitHub Pages preview site）の実装予定があるようです。
    - https://github.com/actions/deploy-pages/blob/d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e/README.md
    - > Is this attempting to deploy a pull request as a GitHub Pages preview site? (NOTE: This feature is only in alpha currently and is not available to the public!)