### PR TITLE
PRに対応するプレビューディレクトリがない場合にエラーになる不具合を修正

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
           BASE_URL: /2025-preview/${{ github.event.number }}
       - name: Deploy to preview repo
         run: |
-          rm -r ./preview/$PR_NUMBER
+          rm -rf ./preview/$PR_NUMBER
           cp -r ./main/dist ./preview/$PR_NUMBER
           cd ./preview
           


### PR DESCRIPTION
https://github.com/GoWorkshopConference/2025/pull/36 の不具合修正です。