### PR TITLE
スタッフ募集フォームへのリンクを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ import Layout from "../layouts/Layout.astro";
               href="https://docs.google.com/forms/d/e/1FAIpQLSfQMTjI0kG8Xq1j4K-aBZh_o6AdT8tv8xgDcuC0NVSM47cS4g/viewform"
             >
               <span
-                class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white dark:bg-gray-900 rounded-md group-hover:bg-transparent group-hover:dark:bg-transparent"
+                class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-transparent"
               >
                 お申し込みフォームはこちら
               </span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,6 +62,30 @@ import Layout from "../layouts/Layout.astro";
             〒651-0082 兵庫県神戸市中央区小野浜町 1-4
           </dd>
         </dl>
+        <div
+          class="text-center p-8 border border-gray-200 rounded-lg shadow-sm"
+        >
+          <h2 class="mb-4 text-xl text-gray-600 font-semibold">
+            スタッフ募集中です！
+          </h2>
+          <div class="text-lg space-y-4">
+            <p>
+              当日・事前準備のお手伝いをしてくださる方を募集しています。<br />
+              イベント運営の経験は不問です。<br />
+              興味のある方はぜひお申し込みください！
+            </p>
+            <a
+              class="inline-flex items-center justify-center p-0.5 text-sm font-medium text-gray-600 font-semibold rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 hover:ring-2 hover:ring-blue-300"
+              href="https://docs.google.com/forms/d/e/1FAIpQLSfQMTjI0kG8Xq1j4K-aBZh_o6AdT8tv8xgDcuC0NVSM47cS4g/viewform"
+            >
+              <span
+                class="relative px-5 py-2.5 transition-all ease-in duration-75 bg-white dark:bg-gray-900 rounded-md group-hover:bg-transparent group-hover:dark:bg-transparent"
+              >
+                お申し込みフォームはこちら
+              </span>
+            </a>
+          </div>
+        </div>
         <div>
           <a
             href="https://twitter.com/goconjp?ref_src=twsrc%5Etfw"


### PR DESCRIPTION
当日・前日スタッフの応募フォームへのリンクをトップページに追加します。
↓のcloudflare-workers-and-pagesのリンクからプレビューが確認できます。