### PR TITLE
本番環境でOGPの画像のURLがhttp://localhost:4321/...になる不具合を修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,30 @@
 import { defineConfig } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 
+const getSiteAndBase = () => {
+  if (import.meta.env.DEV) {
+    return {
+      base: "/2025",
+    };
+  }
+
+  // Cloudflare Pagesの場合はCF_PAGES_URLを使用
+  if (process.env.CF_PAGES_URL) {
+    return {
+      site: process.env.CF_PAGES_URL,
+    };
+  }
+  
+  // それ以外の場合は本番環境のURLを使用
+  return {
+    site: "https://gwc.gocon.jp",
+    base: "/2025",
+  };
+};
+
 // https://astro.build/config
 export default defineConfig({
-  base: process.env.BASE_URL || "/2025",
+  ...getSiteAndBase(),
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,8 @@
 ---
 import "../styles/global.css";
+import { withBase } from "../utils/withBase";
 
-const ogpImageURL = new URL("/ogp.png", Astro.url);
+const ogpImageURL = new URL(withBase("ogp.png"), Astro.site);
 ---
 
 <!doctype html>

--- a/src/utils/withBase.ts
+++ b/src/utils/withBase.ts
@@ -1,6 +1,10 @@
+import { join } from "node:path";
+
 /** Astroに設定した[base](https://docs.astro.build/en/reference/configuration-reference/#base)を先頭に付与したパスを返す */
 // Based on https://github.com/GoCon/2024/blob/ddf8dcc1779cbe9a7becc3e6b8538dce1c627323/src/utils/concatWithBase.ts
 export const withBase = (path?: string) => {
-  const base = import.meta.env.BASE_URL;
-  return path ? `${base}/${path}` : base;
+  if (!path) {
+    return import.meta.env.BASE_URL;
+  }
+  return join(import.meta.env.BASE_URL, path);
 };


### PR DESCRIPTION
`Astro.site`のデフォルト値はproductionのビルド時にも`http://localhost:4321/`になるのが原因です。
明示的に`Astro.site`を指定するようにします。