### PR TITLE
pnpm devで起動したときにレンダリングに失敗する問題を修正

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,7 +2,7 @@
 import "../styles/global.css";
 import { withBase } from "../utils/withBase";
 
-const ogpImageURL = new URL(withBase("ogp.png"), Astro.site);
+const ogpImageURL = new URL(withBase("ogp.png"), Astro.url.origin);
 ---
 
 <!doctype html>


### PR DESCRIPTION
`Astro.site`はデフォルトでは`undefined`なので、`new URL()`の第2引数に渡すとエラーになる。現在のURLを示す`Astro.url`は常に値があり、絶対URLであることが期待できるようなので、こちらを使う。

サブディレクトリの`withBase()`はURLのパス部分をすべて返すので、`new URL(withBase(...), ...)`とすると、第2引数の値はホスト名だけが残る。第2引数は`Astro.url`でもよいが、意図を明示するために`Astro.url.origin`とする。