### PR TITLE
暗黙的にinline扱いされていた<script>にis:inline属性を追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -96,6 +96,7 @@ import Layout from "../layouts/Layout.astro";
             class="twitter-follow-button"
             data-show-count="false">Follow @goconjp</a
           ><script
+            is:inline
             async
             src="https://platform.twitter.com/widgets.js"
             charset="utf-8"></script>


### PR DESCRIPTION
async要素があるので自動的にis:inline属性が付けられていたが、ビルド時に警告が表示されていた。

```
src/pages/index.astro:99:13 - warning astro(4000): This script will be treated as if it has the `is:inline` directive because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.

See docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.

Add the `is:inline` directive explicitly to silence this hint.

99             async
               ~~~~~
```