### PR TITLE
Renovateのパッケージ更新後に自動でpnpm dedupeする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,8 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
+  ],
+  "postUpdateOptions": [
+    "pnpmDedupe"
   ]
 }


### PR DESCRIPTION
PR#147 のように、今後もAstroなどのパッケージを更新した際にpnpm dedupeが必要になりそうなので、Renovateの更新時に自動で行われるように設定する。