### PR TITLE
Node.jsのバージョンを22から24に上げる

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
       
       # 必要なパッケージをインストールして、pnpm run buildを実行する
       - uses: withastro/action@v4
+        with:
+          node-version: 24
       
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. 必要なツールをインストールする
     - 以下のツールをインストールしてください。
-      - [Node.js](https://nodejs.org/en/download/package-manager): v22.x
+      - [Node.js](https://nodejs.org/en/download/package-manager): v24.x
       - [pnpm](https://pnpm.io/installation): v10.x
 2. 依存パッケージをインストールする
     - `pnpm install`を実行してください。


### PR DESCRIPTION
最新版のLTSがリリースされたので上げてみます。

https://nodejs.org/ja/blog/release/v24.0.0