### PR TITLE
スタッフページを追加する

### DIFF
--- a/src/components/StaffCard.astro
+++ b/src/components/StaffCard.astro
@@ -1,0 +1,12 @@
+---
+const { name, image, link, organization } = Astro.props;
+---
+
+<a
+  href={link}
+  class="flex flex-col gap-2 items-center size-md rounded shadow-lg p-8"
+>
+  <img class="size-24 rounded-full shadow-lg" src={image} />
+  <div class="font-bold text-xl">{name}</div>
+  {organization && <div class="text-sm text-gray-500">{organization}</div>}
+</a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,9 @@
+import { defineCollection } from "astro:content";
+
+import { glob } from "astro/loaders";
+
+const staff = defineCollection({
+  loader: glob({ pattern: "*.json", base: "src/data/staff" }),
+});
+
+export const collections = { staff };

--- a/src/data/staff/_gopher.json.example
+++ b/src/data/staff/_gopher.json.example
@@ -1,0 +1,5 @@
+{
+  "name": "Gopher",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang"
+}

--- a/src/data/staff/_gopher.json.example
+++ b/src/data/staff/_gopher.json.example
@@ -1,5 +1,0 @@
-{
-  "name": "Gopher",
-  "image": "https://github.com/golang.png",
-  "link": "https://github.com/golang"
-}

--- a/src/data/staff/gopher1.json
+++ b/src/data/staff/gopher1.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gopher1",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang",
+  "organization": "Go Inc."
+}

--- a/src/data/staff/gopher2.json
+++ b/src/data/staff/gopher2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gopher2",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang",
+  "organization": "Go Inc."
+}

--- a/src/data/staff/gopher3.json
+++ b/src/data/staff/gopher3.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gopher3",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang",
+  "organization": "Go Inc."
+}

--- a/src/data/staff/gopher4.json
+++ b/src/data/staff/gopher4.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gopher4",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang",
+  "organization": "Go Inc."
+}

--- a/src/data/staff/gopher5.json
+++ b/src/data/staff/gopher5.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gopher5",
+  "image": "https://github.com/golang.png",
+  "link": "https://github.com/golang",
+  "organization": "Go Inc."
+}

--- a/src/pages/staff.astro
+++ b/src/pages/staff.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "../layouts/Layout.astro";
+import StaffCard from "../components/StaffCard.astro";
+import { getCollection } from "astro:content";
+
+const staff = await getCollection("staff");
+---
+
+<Layout>
+  <main>
+    <section class="flex flex-col items-center">
+      <h2 class="text-4xl font-bold my-8">Staff</h2>
+      <div class="grid md:grid-cols-3 gap-12">
+        {
+          staff.map((staff) => (
+            <StaffCard
+              name={staff.data.name}
+              organization={staff.data.organization}
+              image={staff.data.image}
+              link={staff.data.link}
+            />
+          ))
+        }
+      </div>
+    </section>
+  </main>
+</Layout>


### PR DESCRIPTION
イベントのスタッフページを追加します。

### 目的

誰が運営しているのかを明示することで、イベント運営の透明性を担保するのが主な目的です。貢献してくださった方の名前をクレジットとして残すという目的もあります。

### 導線について

ページへの導線はまだ追加していません。このPRがマージされたら、スタッフの皆さんに各自の情報を掲載するPRを出していただき、追加が一段落したところで導線を追加しようと思っています。

### 実装方針

`src/data/staff/`以下に、スタッフ1名につき1つのJSONファイルを作ってもらうようにしてみました。同じファイルを触ってもらうよりも編集ミスやコンフリクトを防ぎやすそうという意図です。

### 掲載する情報

お名前（`name`）、アイコン（`image`）、何らかのURL（`link`）の3点を必須の項目、所属先（`organization`）を任意の項目としています。

今回は会社の活動として参加される方もいらっしゃるようなので、所属先は掲載できたほうがよさそうです。

そのほか、「こういう情報も載せたい」などのご意見あればコメントをお願いします :pray: 
後追いで項目を足すこともできそうなので、スタッフの皆さんに記入してもらう際にも意見を募ろうと思っています。

- 参考: 他のイベントのスタッフ一覧
  - https://gocon.jp/2024/staffs/
  - https://2024.droidkaigi.jp/staff/
  - https://rubykaigi.org/2025/about/
  - [https://vuefes.jp/2024/](https://vuefes.jp/2024/#:~:text=%E9%80%81%E4%BF%A1%E3%81%99%E3%82%8B-,%E3%83%81%E3%83%BC%E3%83%A0,-Vue%20Fes%20Japan)

### 期日

特にありません。