### PR TITLE
getSiteAndBase関数をNetlify向けに修正

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,10 +9,10 @@ const getSiteAndBase = (): Pick<AstroUserConfig, "site" | "base"> => {
     };
   }
 
-  // Cloudflare Pagesの場合はCF_PAGES_URLを使用
-  if (process.env.CF_PAGES_URL) {
+  // Netlify（Pull Requestのプレビューでのみ利用）ではDEPLOY_URLを使用
+  if (process.env.NETLIFY && process.env.DEPLOY_URL) {
     return {
-      site: process.env.CF_PAGES_URL,
+      site: process.env.DEPLOY_URL,
     };
   }
 


### PR DESCRIPTION
GoWorkshopConference/2025#189 の対応の一部です。

getSiteAndBase関数では、ビルド環境に応じてデプロイ先のURLを取得して設定しています。 この関数からCloudflare Pagesのための処理を削除して、Netlifyのための処理に置き換えます。