### PR TITLE
スタッフ一覧のページにtitleを設定する

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,10 @@ import "../styles/global.css";
 import { withBase } from "../utils/withBase";
 
 const ogpImageURL = new URL(withBase("ogp.png"), Astro.url.origin);
+
+const { title } = Astro.props;
+const baseTitle = "Go Workshop Conference 2025 IN KOBE";
+const _title = title ? `${title} | ${baseTitle}` : baseTitle;
 ---
 
 <!doctype html>
@@ -11,7 +15,7 @@ const ogpImageURL = new URL(withBase("ogp.png"), Astro.url.origin);
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <title>Go Workshop Conference 2025 IN KOBE</title>
+    <title>{_title}</title>
     <meta property="og:title" content="Go Workshop Conference 2025 IN KOBE" />
     <meta
       property="og:description"

--- a/src/pages/staff.astro
+++ b/src/pages/staff.astro
@@ -6,7 +6,7 @@ import { getCollection } from "astro:content";
 const staff = await getCollection("staff");
 ---
 
-<Layout>
+<Layout title="Staff">
   <main>
     <section class="flex flex-col items-center">
       <h2 class="text-4xl font-bold my-8">Staff</h2>


### PR DESCRIPTION
スタッフ一覧のページの`<title>`を`Go Workshop Conference 2025 IN KOBE`から`Staff | Go Workshop Conference 2025 IN KOBE`に変更します。