### PR TITLE
「参加申し込みはこちらから」のボタンの配色をロゴ画像に近づける

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,7 +32,7 @@ import Layout from "../layouts/Layout.astro";
               参加費は無料です。ぜひご参加ください！
             </p>
             <a
-              class="inline-flex items-center justify-center p-0.5 text-sm text-gray-600 font-semibold rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 focus:ring-2 focus:outline-none focus:ring-blue-300 hover:ring-2 hover:ring-blue-300 group"
+              class="inline-flex items-center justify-center p-0.5 text-sm text-gray-600 font-semibold rounded-lg bg-gradient-to-br from-sky-600 to-fuchsia-700 focus:ring-2 focus:outline-none focus:ring-sky-300 group"
               href="https://go-workshop-conference.connpass.com/event/362435/"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
以前の仮のロゴに合わせて配色されていたボタンを、現在のロゴ画像に合わせるように変更します。

### スクリーンショット

**通常時**

<img width="1228" height="932" alt="image" src="https://github.com/user-attachments/assets/35288cf5-9ff7-4e80-8060-8efe3541581e" />

**ホバー時**

<img width="1230" height="931" alt="image" src="https://github.com/user-attachments/assets/7940f23a-bddf-4e46-b4eb-520f077f26b7" />
