### PR TITLE
ブース出展申し込みのリンクを追加する

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -83,6 +83,33 @@ const posts = (await getCollection("posts"))
               <span> （10/31まで） </span>
             </div>
           </a>
+          <a
+            class="inline-flex items-center justify-center p-0.5 text-sm text-gray-600 font-semibold rounded-lg bg-gradient-to-br from-sky-600 to-fuchsia-700 focus:ring-2 focus:outline-none focus:ring-sky-300 group"
+            href="https://docs.google.com/forms/d/e/1FAIpQLSfS7_cuv4-Q00YVZjuxmAbL1-xxJgltZ_XyY6ji8TPlfhz4nA/viewform"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <div
+              class="w-full relative px-5 py-2.5 transition-all ease-in duration-75 bg-white rounded-md group-hover:bg-transparent group-hover:text-white flex flex-col items-center justify-center gap-2"
+            >
+              <span class="w-full flex items-center justify-center gap-2">
+                ブース出展を申し込む
+                <svg
+                  class="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 5l7 7-7 7"></path>
+                </svg>
+              </span>
+              <span> （10/31まで） </span>
+            </div>
+          </a>
         </div>
         {
           // ブログ公開時まで一時的に導線を隠す


### PR DESCRIPTION
トップページにブース出展申し込みのリンクを追加します。

申し込みフォームは https://x.com/gophers_jp/status/1975794448555794662 で公開済みです。