### PR TITLE
トップメニューをレスポンシブデザインに対応させる

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,122 @@
+---
+import { withBase } from "../utils/withBase";
+import NavigationItems from "./NavigationItems.astro";
+---
+
+<nav class="mx-4 md:mx-auto mt-4 md:mt-8 md:max-w-content md:w-full font-work-sans font-normal">
+  <div class="flex items-center justify-between">
+    <a href={withBase()} class="w-12 h-12">
+      <img
+        src={withBase("/go_text_navy.png")}
+        alt="Go Workshop Conference 2025 IN KOBE"
+        class="w-full h-full object-contain"
+      />
+    </a>
+    
+    <!-- PC時のナビゲーション（右側） -->
+    <NavigationItems className="hidden md:flex gap-4 md:text-xl" />
+    
+    <!-- SP時のハンバーガーメニュー（右側） -->
+    <div class="menu-wrapper md:hidden">
+      <input type="checkbox" id="menu-toggle" class="hidden" />
+      
+      <label class="menu-icon" for="menu-toggle">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+      
+      <div class="overlay"></div>
+      
+      <div class="menu">
+        <NavigationItems className="flex flex-col gap-2" linkClassName="block py-2" />
+      </div>
+    </div>
+  </div>
+</nav>
+
+<style>
+  .menu-wrapper {
+    position: relative;
+  }
+
+  .menu-icon {
+    width: 40px;
+    height: 30px;
+    cursor: pointer;
+    z-index: 3;
+    display: inline-block;
+  }
+
+  .menu-icon span {
+    display: block;
+    width: 100%;
+    height: 4px;
+    margin: 6px 0;
+    background: #333;
+    border-radius: 2px;
+    transition: 0.4s;
+  }
+
+  #menu-toggle:checked + .menu-icon span:nth-child(1) {
+    transform: translateY(10px) rotate(45deg);
+  }
+  #menu-toggle:checked + .menu-icon span:nth-child(2) {
+    opacity: 0;
+  }
+  #menu-toggle:checked + .menu-icon span:nth-child(3) {
+    transform: translateY(-10px) rotate(-45deg);
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: 0.3s;
+    z-index: 1;
+  }
+
+  #menu-toggle:checked ~ .overlay {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    width: 200px;
+    background: #fff;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    border-radius: 8px;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-10px);
+    transition: all 0.3s ease;
+    z-index: 2;
+    padding: 16px;
+    margin-top: 8px;
+  }
+
+  #menu-toggle:checked ~ .menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+</style>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const menuToggle = document.getElementById('menu-toggle') as HTMLInputElement;
+    const overlay = document.querySelector('.overlay');
+
+    if (overlay && menuToggle) {
+      overlay.addEventListener('click', function() {
+        menuToggle.checked = false;
+      });
+    }
+  });
+</script>
+

--- a/src/components/NavigationItems.astro
+++ b/src/components/NavigationItems.astro
@@ -1,0 +1,33 @@
+---
+import { withBase } from "../utils/withBase";
+
+export interface Props {
+  className?: string;
+  linkClassName?: string;
+}
+
+const { className = "", linkClassName = "" } = Astro.props;
+---
+
+<ul class={className}>
+  <li>
+    <a href={withBase()} class={linkClassName}>Home</a>
+  </li>
+  <li>
+    <a href={withBase("workshops")} class={linkClassName}>Workshops</a>
+  </li>
+  {
+    // ブログ公開時まで一時的に導線を隠す
+    false && (
+      <li>
+        <a href={withBase("posts")} class={linkClassName}>Blog</a>
+      </li>
+    )
+  }
+  <li>
+    <a href={withBase("staff")} class={linkClassName}>Staff</a>
+  </li>
+  <li>
+    <a href={withBase("coc")} class={linkClassName}>Code of Conduct</a>
+  </li>
+</ul>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import { withBase } from "../utils/withBase";
+import Header from "../components/Header.astro";
 
 const eventTitle = "Go Workshop Conference 2025 IN KOBE";
 const eventDescription =
@@ -32,38 +33,7 @@ const pageTitle = title ? `${title} | ${eventTitle}` : eventTitle;
     <meta name="twitter:card" content="summary" />
   </head>
   <body class="min-h-screen flex flex-col gap-4 md:gap-8">
-    <nav class="mx-4 md:mx-auto mt-4 md:mt-8 md:max-w-content md:w-full">
-      <ul class="flex gap-4 md:text-xl">
-        <li>
-          <a href={withBase()}>Home</a>
-        </li>
-        <li>
-          <a href={withBase("workshops")}>Workshops</a>
-        </li>
-        {
-          // ブログ公開時まで一時的に導線を隠す
-          false && (
-            <li>
-              <a href={withBase("posts")}>Blog</a>
-            </li>
-          )
-        }
-        {
-          // ワークショップ公開時まで一時的に導線を隠す
-          false && (
-            <li>
-              <a href={withBase("workshops")}>Workshops</a>
-            </li>
-          )
-        }
-        <li>
-          <a href={withBase("staff")}>Staff</a>
-        </li>
-        <li>
-          <a href={withBase("coc")}>Code of Conduct</a>
-        </li>
-      </ul>
-    </nav>
+    <Header />
     <main class="mx-4 md:mx-auto md:max-w-content flex-grow md:w-full">
       <slot />
     </main>
@@ -98,10 +68,5 @@ const pageTitle = title ? `${title} | ${eventTitle}` : eventTitle;
     margin: 0;
     width: 100%;
     height: 100%;
-  }
-
-  nav {
-    font-family: "Work Sans", sans-serif;
-    font-weight: 450;
   }
 </style>


### PR DESCRIPTION
## チケット
#364 

## 対応内容
- ヘッダーを Header.astro と NavigationItems.astro コンポーネントに分割
  - mobile はハンバーガーメニューで実装
  - オーバーレイを追加して、クリックで閉じる仕様
- ヘッダー左に Go のアイコンを追加(top へのリンク)

## 表示

| PC | mobile(close) | mobile(open) |
|--------|--------|--------|
| <img width="1200" src="https://github.com/user-attachments/assets/856c24e2-25ff-4ef0-a9b2-ffb61627e12c" /> | <img width="400" src="https://github.com/user-attachments/assets/5c912355-3a21-4b94-89f1-b1d667c041b1" /> | <img width="400" src="https://github.com/user-attachments/assets/828f8930-2bc2-4ce0-8e1e-9ea885097ba4" /> | 


## 注意事項
- https://github.com/GoWorkshopConference/2025/pull/363 の内容を考慮する
