### PR TITLE
Xアカウントをgoconjpからgwcjpに変更

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,22 +155,21 @@ const posts = (await getCollection("posts"))
             <dd class="mb-8 text-lg">無料</dd>
             <dt class="mb-2 text-xl text-gray-600 font-semibold">主催</dt>
             <dd class="mb-8 text-lg">
-              Go Workshop Conference 2025 IN KOBE実行委員会
+              <div class="flex flex-col items-center justify-center gap-2">
+                Go Workshop Conference 2025 IN KOBE実行委員会
+                <a
+                  href="https://twitter.com/gwcjp?ref_src=twsrc%5Etfw"
+                  class="twitter-follow-button"
+                  data-show-count="false">Follow @gwcjp</a
+                ><script
+                  async
+                  src="https://platform.twitter.com/widgets.js"
+                  charset="utf-8"></script>
+              </div>
             </dd>
             <dt class="mb-2 text-xl text-gray-600 font-semibold">共催</dt>
             <dd class="text-lg">一般社団法人Gophers Japan</dd>
           </dl>
-          <div>
-            <a
-              href="https://twitter.com/goconjp?ref_src=twsrc%5Etfw"
-              class="twitter-follow-button"
-              data-show-count="false">Follow @goconjp</a
-            ><script
-              is:inline
-              async
-              src="https://platform.twitter.com/widgets.js"
-              charset="utf-8"></script>
-          </div>
         </section>
         <div
           class="text-center p-8 border border-gray-200 rounded-lg shadow-sm"


### PR DESCRIPTION
これまでは一般社団法人Gophers Japanさまの https://x.com/goconjp をお借りしていましたが、今後はGo Workshop Conferenceで https://x.com/gwcjp を運用することになりました。そのため、トップページのXのウィジェットを更新します。

before | after
---|---
<img width="420" height="552" alt="image" src="https://github.com/user-attachments/assets/c0636c0b-512c-4a8d-b199-88df89f02e10" /> | <img width="420" height="560" alt="image" src="https://github.com/user-attachments/assets/eebd39b4-bab2-407d-bd6c-9205cb764a15" />
