### PR TITLE
issues389: safari の表示崩れ修正

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,7 +9,7 @@ import NavigationItems from "./NavigationItems.astro";
       <img
         src={withBase("/goheader.png")}
         alt="Go Workshop Conference 2025 IN KOBE"
-        class="w-full h-full"
+        class="h-full w-auto object-contain max-w-full"
       />
     </a>
     


### PR DESCRIPTION
# チケット
#380 

# 内容

- https://github.com/GoWorkshopConference/2025/pull/384 対応後、safari で表示崩れが発生していたため修正

| env | Before | After |
|--------|--------|--------|
| safari | <img width="323" height="392" alt="image" src="https://github.com/user-attachments/assets/ff1301ef-878a-4a41-8648-b017a4715a6d" /> | <img width="325" height="391" alt="image" src="https://github.com/user-attachments/assets/c7fc439a-5a51-4fd8-8fef-0f5a565139c4" /> |
| chrome | <img width="348" height="434" alt="image" src="https://github.com/user-attachments/assets/38854400-29c8-4d32-87cf-1dc01e9a9692" /> | <img width="348" height="434" alt="image" src="https://github.com/user-attachments/assets/5e490232-b9a0-4a96-af69-4aa510419b8c" /> |